### PR TITLE
The generation at which the  solution is found

### DIFF
--- a/Moo/GeneticAlgorithm/Run.hs
+++ b/Moo/GeneticAlgorithm/Run.hs
@@ -168,14 +168,14 @@ loopWithLog :: (Monad m, Monoid w)
      -- ^ @step@ function to produce the next generation
      -> [Genome a]
      -- ^ initial population
-     -> m (Population a, w)
+     -> m (Population a, Generation, w)
      -- ^ final population
 loopWithLog hook cond step genomes0 = go cond 0 mempty (Left genomes0)
   where
     go cond !i !w !x = do
       x' <- step cond x
       case x' of
-        (StopGA pop) -> return (pop, w)
+        (StopGA pop) -> return (pop, i, w)
         (ContinueGA pop) -> do
                          let w' = mappend w (runHook i pop hook)
                          let cond' = updateCond pop cond

--- a/Moo/GeneticAlgorithm/Types.hs
+++ b/Moo/GeneticAlgorithm/Types.hs
@@ -3,7 +3,8 @@
 module Moo.GeneticAlgorithm.Types
     (
     -- * Data structures
-      Genome
+      Generation
+    , Genome
     , Objective
     , Phenotype
     , Population
@@ -27,6 +28,9 @@ module Moo.GeneticAlgorithm.Types
 
 import Moo.GeneticAlgorithm.Random
 import Control.Parallel.Strategies (parMap, rseq)
+
+-- | A representation of the generation of the population.
+type Generation = Int
 
 -- | A genetic representation of an individual solution.
 type Genome a = [a]


### PR DESCRIPTION
The small code change in this pull requrest does **not change** the core functionality of the library. 

The following changes were made.
1. loopIO (Run.hs)
2. loopWithLog (Run.hs)
3. A new type to represent the **generation** was added in **Type.hs**
### loopIO
- After the stop condition is reached, the generation at which the stop condition was reached is returned.
### loopWithLog
- After the stop condtion is reached, the generation at which the stop condition was reached is returned along with the population and the value of the _writer_ type.
### Generation type
- A new generation type was added to represent the generation of an arbitrary population.
- In this case the **Generation** is merely a type synonym for an **Int**
