### PR TITLE
Revert "Fix compilation for GHC 7.10.2"

### DIFF
--- a/Moo/GeneticAlgorithm/Binary.hs
+++ b/Moo/GeneticAlgorithm/Binary.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {- |
 
@@ -86,26 +87,26 @@ bitsNeeded (from, to) =
 -- binary sequence of minimal length. Use of Gray code means that a
 -- single point mutation leads to incremental change of the encoded
 -- value.
-encodeGray :: (FiniteBits b, Bits b, Integral b) => (b, b) -> b -> [Bool]
+encodeGray :: (Bits b, Integral b) => (b, b) -> b -> [Bool]
 encodeGray = encodeWithCode gray
 
 -- | Decode a binary sequence using Gray code to an integer in the
 -- range @(from, to)@ (inclusive). This is an inverse of 'encodeGray'.
 -- Actual value returned may be greater than @to@.
-decodeGray :: (FiniteBits b, Bits b, Integral b) => (b, b) -> [Bool] -> b
+decodeGray :: (Bits b, Integral b) => (b, b) -> [Bool] -> b
 decodeGray = decodeWithCode binary
 
 -- | Encode an integer number in the range @(from, to)@ (inclusive)
 -- as a binary sequence of minimal length. Use of binary encoding
 -- means that a single point mutation may lead to sudden big change
 -- of the encoded value.
-encodeBinary :: (FiniteBits b, Bits b, Integral b) => (b, b) -> b -> [Bool]
+encodeBinary :: (Bits b, Integral b) => (b, b) -> b -> [Bool]
 encodeBinary = encodeWithCode id
 
 -- | Decode a binary sequence to an integer in the range @(from, to)@
 -- (inclusive). This is an inverse of 'encodeBinary'.  Actual value
 -- returned may be greater than @to@.
-decodeBinary :: (FiniteBits b, Bits b, Integral b) => (b, b) -> [Bool] -> b
+decodeBinary :: (Bits b, Integral b) => (b, b) -> [Bool] -> b
 decodeBinary = decodeWithCode id
 
 -- | Encode a real number in the range @(from, to)@ (inclusive)
@@ -152,14 +153,14 @@ splitEvery :: Int -> [a] -> [[a]]
 splitEvery _ [] = []
 splitEvery n xs = let (nxs,rest) = splitAt n xs in nxs : splitEvery n rest
 
-encodeWithCode :: (FiniteBits b, Bits b, Integral b) => ([Bool] -> [Bool]) -> (b, b) -> b -> [Bool]
+encodeWithCode :: (Bits b, Integral b) => ([Bool] -> [Bool]) -> (b, b) -> b -> [Bool]
 encodeWithCode code (from, to) n =
     let from' = min from to
         to' = max from to
         nbits = bitsNeeded (from', to')
     in  code . take nbits $ toList (n - from') ++ (repeat False)
 
-decodeWithCode :: (FiniteBits b, Bits b, Integral b) => ([Bool] -> [Bool]) -> (b, b) -> [Bool] -> b
+decodeWithCode :: (Bits b, Integral b) => ([Bool] -> [Bool]) -> (b, b) -> [Bool] -> b
 decodeWithCode decode (from, to) bits =
     let from' = min from to
     in  (from' +) . fromList . decode $ bits

--- a/Moo/GeneticAlgorithm/Multiobjective/NSGA2.hs
+++ b/Moo/GeneticAlgorithm/Multiobjective/NSGA2.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Rank2Types, ConstraintKinds, FlexibleContexts #-}
+{-# LANGUAGE Rank2Types, ConstraintKinds #-}
 {- |
 
 NSGA-II. A Fast Elitist Non-Dominated Sorting Genetic

--- a/moo.cabal
+++ b/moo.cabal
@@ -68,13 +68,13 @@ Library
                       , Moo.GeneticAlgorithm.Constraints
                       , Moo.GeneticAlgorithm.Continuous
                       , Moo.GeneticAlgorithm.Multiobjective
-                      , Moo.GeneticAlgorithm.Multiobjective.NSGA2
                       , Moo.GeneticAlgorithm.Random
                       , Moo.GeneticAlgorithm.Run
                       , Moo.GeneticAlgorithm.Statistics
                       , Moo.GeneticAlgorithm.Types
     other-modules:      Moo.GeneticAlgorithm.Crossover
                       , Moo.GeneticAlgorithm.LinAlg
+                      , Moo.GeneticAlgorithm.Multiobjective.NSGA2
                       , Moo.GeneticAlgorithm.Multiobjective.Types
                       , Moo.GeneticAlgorithm.Multiobjective.Metrics
                       , Moo.GeneticAlgorithm.Selection


### PR DESCRIPTION
Unfortunately, I have to revert it because it breaks Continuous Integration builds.

As of now, the beginning of 2016, Drone.io supports only GHC 7.4 and GHC 7.6.
Travis CI supports GHC 7.4, 7.6 and 7.8.

FiniteBits are available [since base-4.7](http://hackage.haskell.org/package/base-4.7.0.1/docs/Data-Bits.html#t:FiniteBits), which is [bundled with GHC 7.8](http://hackage.haskell.org/package/base-4.7.0.0/changelog).

The project should either change the build system to Travis or implement this fix in a backwards-compatible way.