### PR TITLE
This PR updates moo to compile with GHC8.6

### DIFF
--- a/Moo/GeneticAlgorithm/Constraints.hs
+++ b/Moo/GeneticAlgorithm/Constraints.hs
@@ -45,7 +45,7 @@ type ConstraintFunction a b = Genome a -> b
 -- function .>=. lowerBound
 -- lowerBound .<= function <=. upperBound
 -- @
-data (Real b) => Constraint a b
+data Constraint a b
     = LessThan (ConstraintFunction a b) b
     -- ^ strict inequality constraint,
     -- function value is less than the constraint value
@@ -78,7 +78,7 @@ data (Real b) => Constraint a b
 
 -- Left hand side of the double inequality defined in the form:
 -- @lowerBound .<= function <=. upperBound@.
-data (Real b) => LeftHandSideInequality a b
+data LeftHandSideInequality a b
     = LeftHandSideInequality (ConstraintFunction a b) (Bool, b)
     -- ^ boolean flag indicates if the bound is inclusive
 

--- a/Moo/GeneticAlgorithm/Continuous.hs
+++ b/Moo/GeneticAlgorithm/Continuous.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {- |
 
@@ -55,7 +55,6 @@ import Moo.GeneticAlgorithm.Random
 import Moo.GeneticAlgorithm.Selection
 import Moo.GeneticAlgorithm.Types
 import Moo.GeneticAlgorithm.Run
-import Moo.GeneticAlgorithm.Random
 import Moo.GeneticAlgorithm.Utilities (getRandomGenomes)
 
 
@@ -160,12 +159,14 @@ unimodalCrossover sigma_xi sigma_eta (x1:x2:x3:rest) = do
       if norm2 d > 1e-6
       then do -- distinct parents
         let exs = drop 1 . mkBasis $ d
-        (xi:etas) <- getNormals n
-        let xi' = sigma_xi * xi
-        let parCorr = xi' `scale` d
-        let etas' = map (dist3 * sigma_eta *) etas
-        let orthCorrs = zipWith scale etas' exs
-        return (parCorr, orthCorrs)
+        getNormals n >>= \case
+          (xi:etas) -> let
+              xi' = sigma_xi * xi
+              parCorr = xi' `scale` d
+              etas' = map (dist3 * sigma_eta *) etas
+              orthCorrs = zipWith scale etas' exs
+            in return (parCorr, orthCorrs)
+          _ -> error "Parameters too short"
       else do -- identical parents, direction d is undefined
         let exs = map (basisVector n) [0..n-1]
         etas <- getNormals n

--- a/Moo/GeneticAlgorithm/Multiobjective/NSGA2.hs
+++ b/Moo/GeneticAlgorithm/Multiobjective/NSGA2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Rank2Types, ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {- |
 
 NSGA-II. A Fast Elitist Non-Dominated Sorting Genetic

--- a/Moo/GeneticAlgorithm/Utilities.hs
+++ b/Moo/GeneticAlgorithm/Utilities.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {- |
 
 Common utility functions.
@@ -17,7 +16,6 @@ import Moo.GeneticAlgorithm.Types
 import Moo.GeneticAlgorithm.Random
 
 
-import Control.Monad.Mersenne.Random
 import Control.Monad (replicateM)
 
 
@@ -32,7 +30,7 @@ randomGenomes :: (Random a, Ord a)
 randomGenomes rng n ranges =
     let sortRange (r1,r2) = (min r1 r2, max r1 r2)
         ranges' = map sortRange ranges
-    in  flip runRandom rng $
+    in  flip runRand rng $
         replicateM n $ mapM getRandomR ranges'
 
 
@@ -43,11 +41,9 @@ randomGenomes rng n ranges =
 getRandomGenomes :: (Random a, Ord a)
                          => Int  -- ^ @n@, how many genomes to generate
                          -> [(a, a)]  -- ^ ranges for individual genome elements
-                         -> Rand ([Genome a])  -- ^ random genomes
+                         -> Rand [Genome a]  -- ^ random genomes
 getRandomGenomes n ranges =
-    Rand $ \rng ->
-        let (gs, rng') = randomGenomes rng n ranges
-        in  R gs rng'
+    liftRand $ \rng -> randomGenomes rng n ranges
 
 
 -- | Crossover all available parents. Parents are not repeated.
@@ -76,6 +72,6 @@ doNCrossovers n parents xover =
         | i <= 0     = return . take n . concat $ children
         | otherwise  = do
       (children', _) <- xover =<< shuffle parents
-      if (null children')
-          then doAnotherNCrossovers 0 children  -- no more children
-          else doAnotherNCrossovers (i - length children') (children':children)
+      if null children'
+      then doAnotherNCrossovers 0 children  -- no more children
+      else doAnotherNCrossovers (i - length children') (children':children)

--- a/Moo/GeneticAlgorithm/Utilities.hs
+++ b/Moo/GeneticAlgorithm/Utilities.hs
@@ -73,5 +73,5 @@ doNCrossovers n parents xover =
         | otherwise  = do
       (children', _) <- xover =<< shuffle parents
       if null children'
-      then doAnotherNCrossovers 0 children  -- no more children
-      else doAnotherNCrossovers (i - length children') (children':children)
+        then doAnotherNCrossovers 0 children  -- no more children
+        else doAnotherNCrossovers (i - length children') (children':children)

--- a/Tests/Internals/TestConstraints.hs
+++ b/Tests/Internals/TestConstraints.hs
@@ -35,7 +35,7 @@ testConstraints =
         let fI = fromIntegral :: Int -> Double
         let constraints = [ 1 .<= (fI . decodeBinary (0,255)) <=. 42 ]
         let n = 200
-        let genomes = flip evalRandom (pureMT 1) $
+        let genomes = flip evalRand (pureMT 1) $
                       getConstrainedBinaryGenomes constraints n 8
         assertEqual "exactly n genomes" n $
                     length genomes
@@ -53,10 +53,10 @@ testConstraints =
         let badvsugly = map (\x -> ([x], x)) [-1, -2]
         -- out of two solutions, one is feasible, the other is not
         let goodvsbad = map (\x -> ([x], x)) [0, -1]
-        let result = flip evalRandom (pureMT 1) $ ctournament badvsugly
+        let result = flip evalRand (pureMT 1) $ ctournament badvsugly
         assertEqual "lesser degree of violation is preferred"
                     (replicate n (-1.0)) $ (map (head . takeGenome) result)
-        let result = flip evalRandom (pureMT 1) $ ctournament goodvsbad
+        let result = flip evalRand (pureMT 1) $ ctournament goodvsbad
         assertEqual "feasible solution is preferred"
                     (replicate n (0.0)) $ (map (head . takeGenome) result)
     , "numberOfViolations" ~: do

--- a/Tests/Internals/TestControl.hs
+++ b/Tests/Internals/TestControl.hs
@@ -23,13 +23,13 @@ testControl =
         let objective = (fromIntegral . length) :: [Int] -> Double
         assertEqual "stop at initial population"  -- initial population is not changed
                     (StopGA [([1],1.0),([2,2],2.0)]) $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                              (nextGeneration Minimizing objective select 0 noCrossover noMutation)
                              (Generations 0) (Left [[1],[2,2]])
         assertEqual "do at least one step"
                     (ContinueGA [([1],1.0),([1],1.0),([1],1.0),([1],1.0)
                                 ,([1],1.0),([1],1.0),([1],1.0),([1],1.0)]) $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                              (nextGeneration Minimizing objective select 0 noCrossover noMutation)
                              (Generations 1) (Left [[1],[2,2]])
     ]

--- a/Tests/Internals/TestCrossover.hs
+++ b/Tests/Internals/TestCrossover.hs
@@ -16,24 +16,24 @@ testCrossover =
     TestList
     [ "do N crossovers" ~: do
         let genomes = [[1,1,1,1],[0,0,0,0]] :: [[Int]]
-        let result4 = flip evalRandom (pureMT 1) $
+        let result4 = flip evalRand (pureMT 1) $
                       doNCrossovers 4 genomes (onePointCrossover 0.5)
         let expected4 = [[0,0,1,1],[1,1,0,0],[0,0,0,1],[1,1,1,0]]
         assertEqual "4 crossovers" expected4 result4
-        let result3 = flip evalRandom (pureMT 1) $
+        let result3 = flip evalRand (pureMT 1) $
                       doNCrossovers 3 genomes (onePointCrossover 0.5)
         let expected3 = [[0,0,1,1],[1,1,0,0],[0,0,0,1]]
         assertEqual "3 crossovers" expected3 result3
     , "do all crossovers" ~: do
         let genomes = [[1,1,1,1],[0,0,0,0]] :: [[Int]]
-        let result = flip evalRandom (pureMT 1) $
+        let result = flip evalRand (pureMT 1) $
                      doCrossovers genomes (onePointCrossover 0.5)
         let expected = [[1,1,1,0],[0,0,0,1]]
         assertEqual "all crossovers (2 genomes)" expected result
         let genomes3 = [[1,1,1,1],[0,0,0,0],[2,2,2,2]] :: [[Int]]
         -- genes from the last "celibate" genome are lost
         let result3 = filter (==2) . concat . map concat . flip map [0..100] $
-                      \i -> flip evalRandom (pureMT i) $
+                      \i -> flip evalRand (pureMT i) $
                       doCrossovers genomes (onePointCrossover 1.0)
         assertEqual "discard last genomes without a pair" [] result3
     , "simple crossover" ~: do
@@ -43,7 +43,7 @@ testCrossover =
         let n = 1000
         assertEqual "exactly one crossover point" True $
                     all (<=2) . map (length . group) $
-                        flip evalRandom (pureMT 1) (doNCrossovers n genomes (onePointCrossover 1))
+                        flip evalRand (pureMT 1) (doNCrossovers n genomes (onePointCrossover 1))
     , "simple crossover" ~: do
         let ones = replicate 8 1
         let zeros = replicate 8 0
@@ -51,7 +51,7 @@ testCrossover =
         let n = 1000
         assertEqual "exactly one crossover point" True $
                     all (<=2) . map (length . group) $
-                        flip evalRandom (pureMT 1) (doNCrossovers n genomes (onePointCrossover 1))
+                        flip evalRand (pureMT 1) (doNCrossovers n genomes (onePointCrossover 1))
     , "two-point crossover" ~: do
         let ones = replicate 8 1
         let zeros = replicate 8 0
@@ -59,15 +59,15 @@ testCrossover =
         let n = 1000
         assertEqual "exactly two crossover point" True $
                     all (<=3) . map (length . group) $
-                        flip evalRandom (pureMT 1) (doNCrossovers n genomes (twoPointCrossover 1))
+                        flip evalRand (pureMT 1) (doNCrossovers n genomes (twoPointCrossover 1))
     , "uniform crossover" ~: do
         assertEqual "change all points"
                     ([[0,0,0,0,0,0,0,0,0,0],[1,1,1,1,1,1,1,1,1,1]],[]) $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                              (uniformCrossover 1) [replicate 10 1,replicate 10 (0::Int)]
         assertEqual "change nothing"
                     ([[1,1,1,1,1,1,1,1,1,1],[0,0,0,0,0,0,0,0,0,0]],[]) $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                              (uniformCrossover 0) [replicate 10 1,replicate 10 (0::Int)]
         let n = 1000
         let mu = 0.5*n
@@ -76,7 +76,7 @@ testCrossover =
                       , replicate (round n) 0]
         let xover = uniformCrossover 0.5 :: CrossoverOp Double
         let mkChildren = doNCrossovers 1000 genomes xover :: Rand [Genome Double]
-        let children = flip evalRandom (pureMT 1) mkChildren :: [Genome Double]
+        let children = flip evalRand (pureMT 1) mkChildren :: [Genome Double]
         assertEqual "change approximately half" True $
                     all (\s -> (s >= mu - 4*sigma && s <= mu + 4*sigma)) . map sum $
                         children

--- a/Tests/Internals/TestFundamentals.hs
+++ b/Tests/Internals/TestFundamentals.hs
@@ -20,26 +20,26 @@ testFundamentals =
         assertEqual "multiobjective phenotype" [False] $ takeGenome ([False], [42.0::Double])
     , "withProbability" ~: do
         assertEqual "probability 0" 42 $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                     withProbability 0 (return . (+1)) 42
         assertEqual "probability 1" 43 $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                     withProbability 1 (return . (+1)) 42
     , "pointMutate" ~: do
         let zeros = map (=='1') (replicate 16 '0')
         assertEqual "just 1 bit is changed" (replicate 10 1) $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                          replicateM 10 $
                          return . length . filter id =<< pointMutate 1 zeros
     , "asymmetricMutate" ~: do
         let g = map (=='1') "0000000011111111"  -- 8 bits set
         assertEqual "flip all zeros" 16 $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                          return . length . filter id =<< asymmetricMutate 1 0 g
         assertEqual "flip all ones" 0 $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                          return . length . filter id =<< asymmetricMutate 0 1 g
         assertEqual "flip all" 8 $
-                    flip evalRandom (pureMT 1) $
+                    flip evalRand (pureMT 1) $
                          return . length . filter id =<< asymmetricMutate 1 1 g
     ]

--- a/Tests/Internals/TestMultiobjective.hs
+++ b/Tests/Internals/TestMultiobjective.hs
@@ -140,7 +140,7 @@ testMultiobjective =
         let expected = [([1.0,5.0],1.0),([5.0,1.0],1.0),([1.0,5.0],1.0)
                        ,([5.0,1.0],1.0),([3.0,3.0],1.0),([3.0,3.0],1.0)
                        ,([2.0,4.0],1.0),([2.0,4.0],1.0),([1.0,5.0],1.0)]
-        let result = flip evalRandom (pureMT 1) $
+        let result = flip evalRand (pureMT 1) $
                      loop (Generations 1)
                      (stepNSGA2bt mp noCrossover noMutation) gs
         assertEqual "solutions and ranking" (Set.fromList expected) (Set.fromList result)

--- a/Tests/Internals/TestSelection.hs
+++ b/Tests/Internals/TestSelection.hs
@@ -19,10 +19,10 @@ dummyGenome objval = ([], objval)
 testSelection =
     TestList
     [ "tournamentSelect" ~: do
-        let resultMin = flip evalRandom (pureMT 1) $
+        let resultMin = flip evalRand (pureMT 1) $
                         tournamentSelect Minimizing 3 4 $
                         map dummyGenome [3,2,4]
-        let resultMax = flip evalRandom (pureMT 1) $
+        let resultMax = flip evalRand (pureMT 1) $
                         tournamentSelect Maximizing 2 3 $
                         map dummyGenome [2,3]
         assertEqual "4 times best of 3" [2,2,2,2] $
@@ -33,13 +33,13 @@ testSelection =
         let times = 10
         let tsize = 4
         let genomes = map dummyGenome [1..10]
-        let resultMany = flip evalRandom (pureMT 1) $
+        let resultMany = flip evalRand (pureMT 1) $
                          tournamentSelect Maximizing tsize times $
                          genomes
         let objVals = map takeObjectiveValue resultMany
         -- take the same samples again with the same see
         let samples = map (map (genomes !!)) $
-                      flip evalRandom (pureMT 1) $
+                      flip evalRand (pureMT 1) $
                            replicateM times (randomSampleIndices tsize (length genomes))
         assertEqual "maximum is selected every time" (replicate times True)  $
                     zipWith (\selected xs -> selected == (maximum . map takeObjectiveValue $ xs))
@@ -48,11 +48,11 @@ testSelection =
        let gs = map dummyGenome [1, 9]
        let tries = 100 * 1000 :: Int
        let numOfNines = length . filter (==9.0) . map takeObjectiveValue
-                        . flip evalRandom (pureMT 1) $ rouletteSelect tries $ gs
+                        . flip evalRand (pureMT 1) $ rouletteSelect tries $ gs
        assertEqual "9 is selected from [1,9] 90% of time" 90 (numOfNines `div` 1000)
     , "stochasticUniversalSampling" ~: do
         let gs = map dummyGenome [2,1]
-        let selected = flip evalRandom (pureMT 1) $
+        let selected = flip evalRand (pureMT 1) $
                        stochasticUniversalSampling 12 gs
         assertEqual "counts are fitness proportional" [4, 8] $
              map length [ (filter ((==1) . takeObjectiveValue) selected)

--- a/examples/bench_rcga.hs
+++ b/examples/bench_rcga.hs
@@ -56,14 +56,14 @@ ga select xover mutate = do
 -- apply selection operator the same number of times as in normal GA run
 runSelection select = do
   rng <- newPureMT
-  let pop' = flip evalRandom rng $ doTimes generations select population0
+  let pop' = flip evalRand rng $ doTimes generations select population0
   return . (++" ") . show . minimum . map takeObjectiveValue $ pop'
 
 
 -- apply crossover operator the same number of times as in normal GA run
 runCrossover crossover = do
   rng <- newPureMT
-  let genomes' = flip evalRandom rng $
+  let genomes' = flip evalRand rng $
                  doTimes generations
                  (flip doCrossovers crossover) genomes0
   return . (++" ") . show . minimum . concat $ genomes'
@@ -72,7 +72,7 @@ runCrossover crossover = do
 -- apply mutation operator the same number of times as in normal GA run
 runMutation mutate = do
   rng <- newPureMT
-  let genomes' = flip evalRandom rng $
+  let genomes' = flip evalRand rng $
                  doTimes generations (mapM gm) genomes0
   return . (++" ") . show . minimum . concat $ genomes'
 

--- a/examples/knapsack.hs
+++ b/examples/knapsack.hs
@@ -54,7 +54,7 @@ select = tournamentSelect Maximizing 2 (popsize-elitesize)
 randomProblem ::  IO Problem
 randomProblem = do
   rng <- newPureMT
-  return . flip evalRandom rng $ do
+  return . flip evalRand rng $ do
                       weights <- replicateM items $ getRandomR itemWeight
                       values <- replicateM items $ getRandomR itemValue
                       return $ zip weights values

--- a/moo.cabal
+++ b/moo.cabal
@@ -118,7 +118,7 @@ Test-Suite moo-tests
     , HUnit
     , random >= 0.1
     , random-shuffle >= 0.0.2
-    , monad-mersenne-random
+    , MonadRandom
     , mersenne-random-pure64
     , gray-code >= 0.2.1
     , mtl

--- a/moo.cabal
+++ b/moo.cabal
@@ -50,7 +50,7 @@ extra-source-files: README.md
 
 Library
     build-depends:      base >=4 && < 5
-                      , monad-mersenne-random
+                      , MonadRandom
                       , mersenne-random-pure64
                       , gray-code >= 0.2.1
                       , random >= 0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-1.15
+resolver: nightly-2018-11-11
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -41,7 +41,6 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - gray-code-0.3.1
-- monad-mersenne-random-0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This drops the dependency on monad-mersenne-random, which is
outdated anyway.