### PR TITLE
Minor edits to the documentation and switch markdown for html in the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Moo
 ===
 
+```
+
      ------------------------------------------------
     < Moo. Breeding Genetic Algorithms with Haskell. >
      ------------------------------------------------
@@ -10,6 +12,7 @@ Moo
                     ||----w |
                     ||     ||
 
+```
 
 Installation
 ------------
@@ -17,146 +20,141 @@ Installation
 ### Installation from Hackage
 
 Hackage is a Haskell community's package archive. This is where the
-latest versions of packages are published first.
-To install Moo from Hackage use Cabal-Install:
+latest versions of packages are published first. To install Moo from
+Hackage use Cabal-Install:
 
-  * install Haskell Platform or GHC and Cabal-Install
-  * run `cabal update`
-  * run `cabal install moo`
-
+-   install Haskell Platform or GHC and Cabal-Install
+-   run `cabal update`
+-   run `cabal install moo`
 
 ### Installation with Stack
 
-Stackage is a stable package archive. Stackage builds are supposed to
-be reproducible. Stackage also provides Long Term Support releases.
-To build Moo with Stackage dependencies, use the `stack` tool:
+Stackage is a stable package archive. Stackage builds are supposed to be
+reproducible. Stackage also provides Long Term Support releases. To
+build Moo with Stackage dependencies, use the \`stack\` tool:
 
-  * install [`stack`](https://docs.haskellstack.org/)
-  * if necessary, install GHC: run `stack setup`
-  * run: `stack update`
-  * in the project source directory run: `stack build`
-  * to run tests: `stack test`
-
+-   install [`stack`](https://docs.haskellstack.org/)
+-   if necessary, install GHC by running `stack setup`
+-   run `stack update`
+-   in the project source directory run `stack build`
+-   to run tests `stack test`
 
 ### Build Status
 
 [![Build Status](https://travis-ci.org/astanin/moo.svg?branch=master)](https://travis-ci.org/astanin/moo)
 
-
 Features
 --------
 
-    |                       | Binary GA            | Continuous GA            |
-    |-----------------------+----------------------+--------------------------|
-    |Encoding               | binary bit-string    | sequence of real values  |
-    |                       | Gray bit-string      |                          |
-    |-----------------------+----------------------+--------------------------|
-    |Initialization         |            random uniform                       |
-    |                       |            constrained random uniform           |
-    |                       |            arbitrary custom                     |
-    |-----------------------+-------------------------------------------------|
-    |Objective              |            minimization and maximiation         |
-    |                       |            optional scaling                     |
-    |                       |            optional ranking                     |
-    |                       |            optional niching (fitness sharing)   |
-    |-----------------------+-------------------------------------------------|
-    |Selection              |            roulette                             |
-    |                       |            stochastic universal sampling        |
-    |                       |            tournament                           |
-    |                       |            optional elitism                     |
-    |                       |            optionally constrained               |
-    |                       |            custom non-adaptive ^                |
-    |-----------------------+-------------------------------------------------|
-    |Crossover              |            one-point                            |
-    |                       |            two-point                            |
-    |                       |            uniform                              |
-    |                       |            custom non-adaptive ^                |
-    |                       +----------------------+--------------------------|
-    |                       |                      | BLX-α (blend)            |
-    |                       |                      | SBX (simulated binary)   |
-    |                       |                      | UNDX (unimodal normally  |
-    |                       |                      | distributed)             |
-    |-----------------------+----------------------+--------------------------|
-    |Mutation               | point                | Gaussian                 |
-    |                       | asymmetric           |                          |
-    |                       | constant frequency   |                          |
-    |                       +----------------------+--------------------------|
-    |                       |            custom non-adaptive ^                |
-    |-----------------------+-------------------------------------------------|
-    |Replacement            |            generational with elitism            |
-    |                       |            steady state                         |
-    |-----------------------+-------------------------------------------------|
-    |Stop                   |            number of generations                |
-    |condition              |            values of objective function         |
-    |                       |            stall of objective function          |
-    |                       |            custom or interactive (`loopIO`)     |
-    |                       |            time limit (`loopIO`)                |
-    |                       |            compound conditions (`And`, `Or`)    |
-    |-----------------------+-------------------------------------------------|
-    |Logging                |            pure periodic (any monoid)           |
-    |                       |            periodic with `IO`                   |
-    |-----------------------+-------------------------------------------------|
-    |Constrainted           |            constrained initialization           |
-    |optimization           |            constrained selection                |
-    |                       |            death penalty                        |
-    |-----------------------+-------------------------------------------------|
-    |Multiobjective         |            NSGA-II                              |
-    |optimization           |            constrained NSGA-II                  |
-
-
+<table class="tg">
+  <tr>
+    <th class="tg-9wq8"><span style="font-weight:bold">Role</span></th>
+    <th class="tg-9wq8"><span style="font-weight:bold">Binary parameters</span></th>
+    <th class="tg-9wq8"><span style="font-weight:bold">Continuous parameters</span></th>
+  </tr>
+  <tr>
+    <td class="tg-9wq8">Encoding</td>
+    <td class="tg-9wq8"><br>binary bit-string<br>Gray bit-string<br></td>
+    <td class="tg-9wq8">sequence of real values</td>
+  </tr>
+  <tr>
+    <td class="tg-9wq8">Initialisation</td>
+    <td class="tg-9wq8" colspan="2"><br>random uniform<br>constrained random uniform<br>arbitrary custom<br></td>
+  </tr>
+  <tr>
+    <td class="tg-baqh">Objective</td>
+    <td class="tg-baqh"><br>minimisation and maximisation<br>optional scaling<br>optional ranking<br>optional niching (fitness sharing)<br></td>
+    <td class="tg-baqh"></td>
+  </tr>
+  <tr>
+    <td class="tg-baqh">Selection</td>
+    <td class="tg-baqh" colspan="2"><br>roulette<br>stochastic universal sampling<br>tournament<br>optional elitism<br>optionally constrained<br>custom non-adaptive ^<br></td>
+  </tr>
+  <tr>
+    <td class="tg-baqh" rowspan="2">Crossover</td>
+    <td class="tg-baqh" colspan="2"><br>one-point<br>two-point<br>uniform<br>custom non-adaptive ^<br></td>
+  </tr>
+  <tr>
+    <td class="tg-baqh"></td>
+    <td class="tg-baqh"><br>BLX-alpha (blend)<br>SBX (simulated binary)<br>UNDX (unimodal normally distributed)<br></td>
+  </tr>
+  <tr>
+    <td class="tg-baqh" rowspan="2">Mutation</td>
+    <td class="tg-baqh"><br>point<br>asymmetric<br>constant frequency<br></td>
+    <td class="tg-baqh">Gaussian</td>
+  </tr>
+  <tr>
+    <td class="tg-baqh" colspan="2">custom non-adaptive ^</td>
+  </tr>
+  <tr>
+    <td class="tg-baqh">Replacement</td>
+    <td class="tg-baqh" colspan="2"><br>generational with elitism<br>steady state<br></td>
+  </tr>
+  <tr>
+    <td class="tg-baqh">Stop condition</td>
+    <td class="tg-baqh" colspan="2"><br>number of generations<br>values of objective function<br>stall of objective function<br>custom or interactive (via `loopIO`)<br><br>time limit (via `loopIO`)<br><br>compound conditions (via `And` or `Or`)<br></td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Logging</td>
+    <td class="tg-0lax" colspan="2"><br>pure periodic (any monoid)<br>periodic with IO<br></td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Constrained optimisation</td>
+    <td class="tg-0lax" colspan="2"><br>constrained initialisation<br>constrained selection<br>death penalty</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Multiobjective optimisation</td>
+    <td class="tg-0lax" colspan="2"><br>NSGA-II<br>constrained NSGA-II<br></td>
+  </tr>
+</table>
 `^` non-adaptive: any function which doesn't depend on generation number
 
-There are other possible encodings which are possible to represent
-with list-like genomes (`type Genome a = [a]`):
+The list-like `type Genome a = [a]` makes it possible to encode a
+range of data structures. Here are a couple of examples:
 
-  * permutation encodings (`a` being an integer, or other `Enum` type)
-  * tree encodings (`a` being a subtree type)
-  * hybrid encodings (`a` being a sum type)
-
+-   permutation encodings, where `a` is an integer, or some other `Enum`
+    type
+-   tree encodings, where `a` is a subtree type
+-   hybrid encodings, where `a` is a sum type
 
 Contributing
 ------------
 
-There are many ways you can help developing the library:
+There are many ways in which you can help to develop the library:
 
-  * I'm not a native speaker of English. If you are, please proof-read
-    and correct the comments and the documentation.
-
-  * Moo is designed with possibility of implementing custom genetic
-    operators in mind. If you write new operators (`SelectionOp`,
-    `CrossoverOp`, `MutationOp`) or replacement strategies
-    (`StepGA`), consider contributing them to the library.
-    In the comments please give a reference to an academic
-    work which introduces or studies the method. Explain when or why
-    it should be used. Provide tests and examples if possible.
-
-  * Implementing some methods (like adaptive genetic algorithms) will
-    require to change some library types. Please discuss your approach
-    first.
-
-  * Contribute examples. Solutions of known problems with known optima
-    and interesting properties. Try to avoid examples which are too
-    contrived.
-
-
+-   I'm not a native speaker of English. If you are, please proof-read
+    and correct the comments and documentation.
+-   Moo was designed with the potential of implementing custom genetic
+    operators in mind. If you write new operators --- see `SelectionOp`,
+    `CrossoverOp`, `MutationOp` for example --- or additional
+    replacement strategies --- see `StepGA` --- please consider
+    contributing them to the library. In the comments please give a
+    reference to the academic work (with a DOI preferably) which
+    introduced the method, explain when or why it should be used and
+    provide some tests and examples if possible.
+-   Implementing some methods (like adaptive genetic algorithms) will
+    require changes to be made to some of the library types. Please
+    discuss your approach first by lodging an issue.
+-   Contribute examples. Solutions of known problems with known optima
+    and interesting properties are preferable. Try to avoid examples
+    which are too contrived.
 
 An example
 ----------
 
-Minimizing [Beale's function][test-functions] (optimal value f(3, 0.5) = 0):
+Minimizing [Beale's
+function](http://en.wikipedia.org/wiki/Test_functions_for_optimization)
+which takes its minimum value at $f(3, 0.5) = 0$.
 
 ```haskell
 import Moo.GeneticAlgorithm.Continuous
 
-
 beale :: [Double] -> Double
 beale [x, y] = (1.5 - x + x*y)**2 + (2.25 - x + x*y*y)**2 + (2.625 - x + x*y*y*y)**2
-
 
 popsize = 101
 elitesize = 1
 tolerance = 1e-6
-
 
 selection = tournamentSelect Minimizing 2 (popsize - elitesize)
 crossover = unimodalCrossoverRP
@@ -165,12 +163,9 @@ step = nextGeneration Minimizing beale selection elitesize crossover mutation
 stop = IfObjective (\values -> (minimum values) < tolerance)
 initialize = getRandomGenomes popsize [(-4.5, 4.5), (-4.5, 4.5)]
 
-
 main = do
   population <- runGA initialize (loop stop step)
   print (head . bestFirst Minimizing $ population)
 ```
 
-For more examples, see [examples/](examples/) folder.
-
-[test-functions]: http://en.wikipedia.org/wiki/Test_functions_for_optimization
+For more examples, see the [examples/](examples/) folder.


### PR DESCRIPTION
Fix a couple of typographical errors in the README and switch to using a HTML table over the markdown one. Hopefully this will be easier in the long run to allow for the described functions to be linked to their documentation.